### PR TITLE
ENG-4817: User experience enhancements

### DIFF
--- a/pg/app/main.py
+++ b/pg/app/main.py
@@ -7,6 +7,7 @@ import threading
 import time
 import typing
 import yaml
+from tqdm import tqdm
 
 def parse_pgbench_output(output: str):
     parsed_output = {}
@@ -65,6 +66,10 @@ def main():
             executor.submit(run_pgbench, id, pgbench_args)
             for id in range(app_config['concurrent_instances'])
         ]
+        for i in tqdm(range(app_config['duration'])):
+            if not any([f.running() for f in futures]):
+                break
+            time.sleep(1)
         results = [f.result() for f in futures]
         exceptions = [f.exception() for f in futures]
 

--- a/pg/init/main.py
+++ b/pg/init/main.py
@@ -6,11 +6,7 @@ import yaml
 def run_pgbench(args: typing.List[str]):
     command = ['pgbench']
     command += args
-    result = subprocess.run(command, capture_output=True)
-    if result.returncode != 0:
-        stderr = str(result.stderr, 'utf-8')
-        raise Exception(f'pgbench terminated with a non-zero code. stderr: {stderr}')
-    return str(result.stdout, 'utf-8')
+    subprocess.run(command, check=True)
 
 def parse_config():
     config = {}
@@ -32,8 +28,7 @@ def main():
     ]
     os.environ['PGPASSWORD'] = db_config['password']
 
-    output = run_pgbench(pgbench_args)
-    print(output)
+    run_pgbench(pgbench_args)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
* `init` now prints the `pgbench`'s progress. The output looks like this:
```
dropping old tables...
creating tables...
generating data (client-side)...
100000 of 128000000 tuples (0%) done (elapsed 0.04 s, remaining 56.20 s)
(...)
128000000 of 128000000 tuples (100%) done (elapsed 84.12 s, remaining 0.00 s)
vacuuming...
creating primary keys...

done in 249.12 s (drop tables 2.03 s, create tables 0.01 s, client-side generate 86.33 s, vacuum 133.63 s, primary keys 27.12 s).
```
* `app` now prints a progress bar when the performance tests are running. The output looks like this:
```
100%|██████████| 300/300 [05:00<00:00,  1.00s/it]
Average latency: 104.7765 ms
Average TPS: 1225.1229341
```